### PR TITLE
fix(index): tapable deprecation warnings (webpack >= v4.0.0)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -167,9 +167,18 @@ export default class GoogleFontsWebpackPlugin {
   }
 
   apply (compiler) {
-    compiler.plugin('emit', async (compilation, callback) => {
-      await this.make()
-      callback()
-    })
+    if (compiler.hooks) {
+      const plugin = { name: 'GoogleFontsPlugin' };
+
+      compiler.hooks.emit.tapAsync(plugin, async (compilation, callback) => {
+        await this.make()
+        callback()
+      });
+    } else {
+      compiler.plugin('emit', async (compilation, callback) => {
+        await this.make()
+        callback()
+      })
+    }
   }
 }


### PR DESCRIPTION
Thanks for this great plugin!

`Tapable.plugin` is deprecated for webpack >= 4.0.0. 
This PR makes the plugin to use new API on `.hooks` instead if webpack >=4.0.0 version is used.

(migh need to bump up the version of the plugin in `package.json` to publish on npm)